### PR TITLE
Fixing bugs: index & user id parameters

### DIFF
--- a/lib/src/collection.dart
+++ b/lib/src/collection.dart
@@ -50,6 +50,7 @@ class Collection extends KuzzleObject {
     final prevMap = super.getPartialQuery()
       ..addAll(<String, dynamic>{
         'collection': collectionName,
+        'index': index,
       });
     return prevMap;
   }

--- a/lib/src/security.dart
+++ b/lib/src/security.dart
@@ -44,6 +44,7 @@ class Security extends KuzzleObject {
         },
         optionalParams: <String, dynamic>{
           'refresh': refresh,
+          '_id': user.id,
         },
       ).then((response) => User.fromMap(this, response.result));
 


### PR DESCRIPTION
- Fixed `index` property propagation (over default index) for `Collection` constructor
```dart
import 'package:kuzzle/kuzzle_dart.dart';
...

Future<void> _initKuzzle() async {
  Kuzzle _a_kuzzle_dart_instance = new Kuzzle(
    'localhost', // <-- suppose we don't give a defaultIndex
  );

  Collection  my_collection = _a_kuzzle_dart_instance.collection(
    'my_collection ', 
    index: 'my_index', // <-- this now should work and override defaultIndex 
  );

  await my_collection.publishMessage(<String, dynamic>{
    'message': 'Hello World',
  });
}
...
```
- Fixed `id` property propagation when register new users using `User` constructor
```dart
import 'package:kuzzle/kuzzle_dart.dart';
...

Future<void> _registerUser() async {
  ...

  await _a_kuzzle_dart_instance.register(
    User(
      _a_kuzzle_dart_instance.security, // <- notice about this annoying required parameter
      id: 'should_work_now', // <-- this value should be used as user id as expected
      source: {
        'username': 'pseudo',
      }
    ),
    Credentials(
      LoginStrategy.local,
      username: 'pseudo',
      password: 'aw3some_passw0rd'
    )
  );
}
...
```