### PR TITLE
Rename User, Profile, Role and Room with Kuzzle prefix

### DIFF
--- a/lib/src/controllers/auth.dart
+++ b/lib/src/controllers/auth.dart
@@ -59,13 +59,13 @@ class AuthController extends KuzzleController {
   }
 
   /// Fetches the current user.
-  Future<User> getCurrentUser() async {
+  Future<KuzzleUser> getCurrentUser() async {
     final response = await kuzzle.query(KuzzleRequest(
       controller: name,
       action: 'getCurrentUser',
     ));
 
-    return User.fromKuzzleResponse(kuzzle, response);
+    return KuzzleUser.fromKuzzleResponse(kuzzle, response);
   }
 
   /// Get credential information of
@@ -161,14 +161,14 @@ class AuthController extends KuzzleController {
   }
 
   /// Fetches the current user.
-  Future<User> updateSelf(Map<String, dynamic> body) async {
+  Future<KuzzleUser> updateSelf(Map<String, dynamic> body) async {
     final response = await kuzzle.query(KuzzleRequest(
       controller: name,
       action: 'updateSelf',
       body: body,
     ));
 
-    return User.fromKuzzleResponse(kuzzle, response);
+    return KuzzleUser.fromKuzzleResponse(kuzzle, response);
   }
 
   /// Validate [credentials] of the specified [strategy] for the current user.

--- a/lib/src/controllers/realtime.dart
+++ b/lib/src/controllers/realtime.dart
@@ -10,7 +10,7 @@ import 'abstract.dart';
 class RealTimeController extends KuzzleController {
   RealTimeController(Kuzzle kuzzle) : super(kuzzle, name: 'realtime');
 
-  final Map<String, List<Room>> _subscriptions = {};
+  final Map<String, List<KuzzleRoom>> _subscriptions = {};
 
   /// Returns the number of other connections sharing the same subscription.
   Future<int> count(String roomId) async {
@@ -59,7 +59,7 @@ class RealTimeController extends KuzzleController {
       Map<String, dynamic> volatile,
       bool subscribeToSelf,
       bool autoResubscribe}) async {
-    final room = Room(kuzzle, index, collection, filters, callback,
+    final room = KuzzleRoom(kuzzle, index, collection, filters, callback,
         volatile: volatile,
         users: users,
         scope: scope,
@@ -69,7 +69,7 @@ class RealTimeController extends KuzzleController {
 
     return room.subscribe().then((response) {
       if (!_subscriptions.containsKey(room.id)) {
-        _subscriptions[room.id] = <Room>[];
+        _subscriptions[room.id] = <KuzzleRoom>[];
       }
 
       _subscriptions[room.id].add(room);

--- a/lib/src/controllers/security.dart
+++ b/lib/src/controllers/security.dart
@@ -28,7 +28,7 @@ class SecurityController extends KuzzleController {
   }
 
   /// Creates a Kuzzle administrator account, only if none exist.
-  Future<User> createFirstAdmin(String uid, Map<String, dynamic> credentials,
+  Future<KuzzleUser> createFirstAdmin(String uid, Map<String, dynamic> credentials,
       {Map<String, dynamic> content, bool reset}) async {
     final response = await kuzzle.query(KuzzleRequest(
       controller: name,
@@ -41,12 +41,12 @@ class SecurityController extends KuzzleController {
       },
     ));
 
-    return User.fromKuzzleResponse(kuzzle, response);
+    return KuzzleUser.fromKuzzleResponse(kuzzle, response);
   }
 
   /// Creates a new profile or, if the provided profile
   /// identifier already exists, replaces it.
-  Future<Profile> createOrReplaceProfile(
+  Future<KuzzleProfile> createOrReplaceProfile(
       String uid, List<Map<String, dynamic>> policies,
       {String refresh}) async {
     final response = await kuzzle.query(KuzzleRequest(
@@ -59,12 +59,12 @@ class SecurityController extends KuzzleController {
       },
     ));
 
-    return Profile.fromKuzzleResponse(kuzzle, response);
+    return KuzzleProfile.fromKuzzleResponse(kuzzle, response);
   }
 
   /// Creates a new role or, if the provided role
   /// identifier already exists, replaces it.
-  Future<Role> createOrReplaceRole(String uid, Map<String, dynamic> controllers,
+  Future<KuzzleRole> createOrReplaceRole(String uid, Map<String, dynamic> controllers,
       {String refresh}) async {
     final response = await kuzzle.query(KuzzleRequest(
       controller: name,
@@ -76,11 +76,11 @@ class SecurityController extends KuzzleController {
       },
     ));
 
-    return Role.fromKuzzleResponse(kuzzle, response);
+    return KuzzleRole.fromKuzzleResponse(kuzzle, response);
   }
 
   /// Creates a new profile.
-  Future<Profile> createProfile(String uid, List<Map<String, dynamic>> policies,
+  Future<KuzzleProfile> createProfile(String uid, List<Map<String, dynamic>> policies,
       {String refresh}) async {
     final response = await kuzzle.query(KuzzleRequest(
       controller: name,
@@ -92,7 +92,7 @@ class SecurityController extends KuzzleController {
       },
     ));
 
-    return Profile.fromKuzzleResponse(kuzzle, response);
+    return KuzzleProfile.fromKuzzleResponse(kuzzle, response);
   }
 
   /// Creates a new user in Kuzzle, with a preset list of security profiles.
@@ -103,7 +103,7 @@ class SecurityController extends KuzzleController {
   /// This method allows users with limited rights to create other accounts,
   /// but blocks them from creating accounts with unwanted privileges
   /// (e.g. an anonymous user creating his own account).
-  Future<User> createRestrictedUser(Map<String, dynamic> credentials,
+  Future<KuzzleUser> createRestrictedUser(Map<String, dynamic> credentials,
       {Map<String, dynamic> content, String uid, String refresh}) async {
     final response = await kuzzle.query(KuzzleRequest(
       controller: name,
@@ -116,11 +116,11 @@ class SecurityController extends KuzzleController {
       },
     ));
 
-    return User.fromKuzzleResponse(kuzzle, response);
+    return KuzzleUser.fromKuzzleResponse(kuzzle, response);
   }
 
   /// Creates a new role.
-  Future<Role> createRole(String uid, Map<String, dynamic> controllers,
+  Future<KuzzleRole> createRole(String uid, Map<String, dynamic> controllers,
       {String refresh}) async {
     final response = await kuzzle.query(KuzzleRequest(
       controller: name,
@@ -132,11 +132,11 @@ class SecurityController extends KuzzleController {
       },
     ));
 
-    return Role.fromKuzzleResponse(kuzzle, response);
+    return KuzzleRole.fromKuzzleResponse(kuzzle, response);
   }
 
   /// Creates a new user
-  Future<User> createUser(
+  Future<KuzzleUser> createUser(
       Map<String, dynamic> credentials, Map<String, dynamic> content,
       {String uid, String refresh}) async {
     final response = await kuzzle.query(KuzzleRequest(
@@ -150,7 +150,7 @@ class SecurityController extends KuzzleController {
       },
     ));
 
-    return User.fromKuzzleResponse(kuzzle, response);
+    return KuzzleUser.fromKuzzleResponse(kuzzle, response);
   }
 
   /// Deletes user credentials for the specified authentication strategy.
@@ -262,14 +262,14 @@ class SecurityController extends KuzzleController {
   }
 
   /// Gets a security profile.
-  Future<Profile> getProfile(String uid) async {
+  Future<KuzzleProfile> getProfile(String uid) async {
     final response = await kuzzle.query(KuzzleRequest(
       controller: name,
       action: 'getProfile',
       uid: uid,
     ));
 
-    return Profile.fromKuzzleResponse(kuzzle, response);
+    return KuzzleProfile.fromKuzzleResponse(kuzzle, response);
   }
 
   /// Gets the mapping of the internal security profiles collection.
@@ -294,14 +294,14 @@ class SecurityController extends KuzzleController {
   }
 
   /// Gets a security role.
-  Future<Role> getRole(String uid) async {
+  Future<KuzzleRole> getRole(String uid) async {
     final response = await kuzzle.query(KuzzleRequest(
       controller: name,
       action: 'getRole',
       uid: uid,
     ));
 
-    return Role.fromKuzzleResponse(kuzzle, response);
+    return KuzzleRole.fromKuzzleResponse(kuzzle, response);
   }
 
   /// Gets the mapping of the internal security role collection.
@@ -315,14 +315,14 @@ class SecurityController extends KuzzleController {
   }
 
   /// Gets a security role.
-  Future<User> getUser(String uid) async {
+  Future<KuzzleUser> getUser(String uid) async {
     final response = await kuzzle.query(KuzzleRequest(
       controller: name,
       action: 'getUser',
       uid: uid,
     ));
 
-    return User.fromKuzzleResponse(kuzzle, response);
+    return KuzzleUser.fromKuzzleResponse(kuzzle, response);
   }
 
   /// Gets the mapping of the internal security user collection.
@@ -404,7 +404,7 @@ class SecurityController extends KuzzleController {
   }
 
   /// Gets multiple security profiles.
-  Future<List<Profile>> mGetProfiles(List<String> ids, {String refresh}) async {
+  Future<List<KuzzleProfile>> mGetProfiles(List<String> ids, {String refresh}) async {
     final response = await kuzzle.query(KuzzleRequest(
         controller: name,
         action: 'mGetProfiles',
@@ -412,10 +412,10 @@ class SecurityController extends KuzzleController {
           'ids': ids,
         }));
 
-    final profiles = <Profile>[];
+    final profiles = <KuzzleProfile>[];
 
     for (final hit in response.result['hits']) {
-      profiles.add(Profile(kuzzle,
+      profiles.add(KuzzleProfile(kuzzle,
           uid: hit['_id'] as String,
           policies: hit['_source']['policies'] as List<dynamic>));
     }
@@ -424,7 +424,7 @@ class SecurityController extends KuzzleController {
   }
 
   /// Gets multiple security roles.
-  Future<List<Role>> mGetRoles(List<String> ids, {String refresh}) async {
+  Future<List<KuzzleRole>> mGetRoles(List<String> ids, {String refresh}) async {
     final response = await kuzzle.query(KuzzleRequest(
         controller: name,
         action: 'mGetRoles',
@@ -432,10 +432,10 @@ class SecurityController extends KuzzleController {
           'ids': ids,
         }));
 
-    final roles = <Role>[];
+    final roles = <KuzzleRole>[];
 
     for (final hit in response.result['hits']) {
-      roles.add(Role(kuzzle,
+      roles.add(KuzzleRole(kuzzle,
           uid: hit['_id'] as String,
           controllers: hit['_source']['controllers'] as Map<String, dynamic>));
     }
@@ -444,7 +444,7 @@ class SecurityController extends KuzzleController {
   }
 
   /// Replaces a user with new configuration.
-  Future<User> replaceUser(Map<String, dynamic> content,
+  Future<KuzzleUser> replaceUser(Map<String, dynamic> content,
       {String uid, String refresh}) async {
     final response = await kuzzle.query(KuzzleRequest(
       controller: name,
@@ -454,7 +454,7 @@ class SecurityController extends KuzzleController {
       body: content,
     ));
 
-    return User.fromKuzzleResponse(kuzzle, response);
+    return KuzzleUser.fromKuzzleResponse(kuzzle, response);
   }
 
   /// Searches security profiles, optionally returning
@@ -522,7 +522,7 @@ class SecurityController extends KuzzleController {
   }
 
   /// Updates a security profile definition.
-  Future<Profile> updateProfile(String uid, List<dynamic> policies,
+  Future<KuzzleProfile> updateProfile(String uid, List<dynamic> policies,
       {String refresh}) async {
     final response = await kuzzle.query(KuzzleRequest(
       controller: name,
@@ -534,7 +534,7 @@ class SecurityController extends KuzzleController {
       },
     ));
 
-    return Profile.fromKuzzleResponse(kuzzle, response);
+    return KuzzleProfile.fromKuzzleResponse(kuzzle, response);
   }
 
   /// Updates the internal profile storage mapping.
@@ -555,7 +555,7 @@ class SecurityController extends KuzzleController {
   ///
   /// Note: partial updates are not supported for roles,
   /// this API route will replace the entire role content with the provided one.
-  Future<Role> updateRole(String uid, Map<String, dynamic> controllers,
+  Future<KuzzleRole> updateRole(String uid, Map<String, dynamic> controllers,
       {String refresh}) async {
     final response = await kuzzle.query(KuzzleRequest(
       controller: name,
@@ -567,7 +567,7 @@ class SecurityController extends KuzzleController {
       },
     ));
 
-    return Role.fromKuzzleResponse(kuzzle, response);
+    return KuzzleRole.fromKuzzleResponse(kuzzle, response);
   }
 
   /// Updates the internal role storage mapping.
@@ -585,7 +585,7 @@ class SecurityController extends KuzzleController {
   }
 
   /// Updates a user definition.
-  Future<User> updateUser(Map<String, dynamic> content,
+  Future<KuzzleUser> updateUser(Map<String, dynamic> content,
       {String uid, String refresh}) async {
     final response = await kuzzle.query(KuzzleRequest(
       controller: name,
@@ -595,7 +595,7 @@ class SecurityController extends KuzzleController {
       body: content,
     ));
 
-    return User.fromKuzzleResponse(kuzzle, response);
+    return KuzzleUser.fromKuzzleResponse(kuzzle, response);
   }
 
   /// Updates the internal user storage mapping.

--- a/lib/src/kuzzle/profile.dart
+++ b/lib/src/kuzzle/profile.dart
@@ -3,14 +3,14 @@ import '../kuzzle/response.dart';
 
 import 'role.dart';
 
-class Profile {
-  Profile(
+class KuzzleProfile {
+  KuzzleProfile(
     this.kuzzle, {
     this.uid,
     this.policies,
   });
 
-  Profile.fromKuzzleResponse(this.kuzzle, KuzzleResponse response) {
+  KuzzleProfile.fromKuzzleResponse(this.kuzzle, KuzzleResponse response) {
     uid = response.result['_id'] as String;
     policies = response.result['_source']['policies'] as List<dynamic>;
   }
@@ -19,9 +19,9 @@ class Profile {
   String uid;
   List<dynamic> policies;
 
-  Future<List<Role>> getRoles() async {
+  Future<List<KuzzleRole>> getRoles() async {
     if (policies == null || policies.isEmpty) {
-      return <Role>[];
+      return <KuzzleRole>[];
     }
 
     return kuzzle.security

--- a/lib/src/kuzzle/role.dart
+++ b/lib/src/kuzzle/role.dart
@@ -1,14 +1,14 @@
 import '../kuzzle.dart';
 import '../kuzzle/response.dart';
 
-class Role {
-  Role(
+class KuzzleRole {
+  KuzzleRole(
     this.kuzzle, {
     this.uid,
     this.controllers,
   });
 
-  Role.fromKuzzleResponse(this.kuzzle, KuzzleResponse response) {
+  KuzzleRole.fromKuzzleResponse(this.kuzzle, KuzzleResponse response) {
     uid = response.result['_id'] as String;
     controllers =
         response.result['_source']['controllers'] as Map<String, dynamic>;

--- a/lib/src/kuzzle/room.dart
+++ b/lib/src/kuzzle/room.dart
@@ -4,8 +4,9 @@ import '../kuzzle/response.dart';
 
 typedef RoomListener = void Function(KuzzleResponse);
 
-class Room {
-  Room(this.kuzzle, this.index, this.collection, this.filters, this.callback,
+class KuzzleRoom {
+  KuzzleRoom(
+      this.kuzzle, this.index, this.collection, this.filters, this.callback,
       {this.state,
       this.scope,
       this.users,

--- a/lib/src/kuzzle/user.dart
+++ b/lib/src/kuzzle/user.dart
@@ -3,15 +3,15 @@ import '../kuzzle/response.dart';
 
 import 'profile.dart';
 
-class User {
-  User(
+class KuzzleUser {
+  KuzzleUser(
     this.kuzzle, {
     this.uid,
     this.content,
     this.meta,
   });
 
-  User.fromKuzzleResponse(this.kuzzle, KuzzleResponse response) {
+  KuzzleUser.fromKuzzleResponse(this.kuzzle, KuzzleResponse response) {
     uid = response.result['_id'] as String;
     content = response.result['_source'] as Map<String, dynamic>;
     meta = response.result['_meta'] as Map<String, dynamic>;
@@ -28,9 +28,9 @@ class User {
           .toList()
       : <String>[];
 
-  Future<List<Profile>> getProfiles() async {
+  Future<List<KuzzleProfile>> getProfiles() async {
     if (profileIds == null || profileIds.isEmpty) {
-      return <Profile>[];
+      return <KuzzleProfile>[];
     }
 
     return kuzzle.security.mGetProfiles(profileIds);

--- a/lib/src/search_result/profiles.dart
+++ b/lib/src/search_result/profiles.dart
@@ -15,16 +15,16 @@ class ProfileSearchResult extends KuzzleSearchResult {
     searchAction = 'searchProfiles';
     scrollAction = 'scrollProfiles';
 
-    hits = (response.result['hits'] as List).map((hit) => Profile(kuzzle,
+    hits = (response.result['hits'] as List).map((hit) => KuzzleProfile(kuzzle,
         uid: hit['_id'] as String,
         policies: hit['_source']['policies'] as List)) as List<dynamic>;
   }
 
   @override
   Future<List<dynamic>> next() => super.next().then((_) => hits =
-      (response.result['hits'] as List).map((hit) => Profile(kuzzle,
+      (response.result['hits'] as List).map((hit) => KuzzleProfile(kuzzle,
           uid: hit['_id'] as String,
           policies: hit['_source']['policies'] as List)) as List<dynamic>);
 
-  List<Profile> getRoles() => List<Profile>.from(hits);
+  List<KuzzleProfile> getRoles() => List<KuzzleProfile>.from(hits);
 }

--- a/lib/src/search_result/roles.dart
+++ b/lib/src/search_result/roles.dart
@@ -16,7 +16,7 @@ class RoleSearchResult extends KuzzleSearchResult {
     searchAction = 'searchRoles';
     scrollAction = null; // scrollRoles action does not exists in Kuzzle API.
 
-    hits = (response.result['hits'] as List).map((hit) => Role(kuzzle,
+    hits = (response.result['hits'] as List).map((hit) => KuzzleRole(kuzzle,
             uid: hit['_id'] as String,
             controllers: hit['_source']['controllers'] as Map<String, dynamic>))
         as List<dynamic>;
@@ -29,11 +29,11 @@ class RoleSearchResult extends KuzzleSearchResult {
     }
 
     return super.next().then((_) => hits = (response.result['hits'] as List)
-        .map((hit) => Role(kuzzle,
+        .map((hit) => KuzzleRole(kuzzle,
             uid: hit['_id'] as String,
             controllers: hit['_source']['controllers']
                 as Map<String, dynamic>)) as List<dynamic>);
   }
 
-  List<Role> getRoles() => List<Role>.from(hits);
+  List<KuzzleRole> getRoles() => List<KuzzleRole>.from(hits);
 }

--- a/lib/src/search_result/users.dart
+++ b/lib/src/search_result/users.dart
@@ -16,7 +16,7 @@ class UserSearchResult extends KuzzleSearchResult {
     scrollAction = 'scrollUsers';
 
     hits = response.result['hits']
-        .map((hit) => User(kuzzle,
+        .map((hit) => KuzzleUser(kuzzle,
             uid: hit['_id'] as String,
             content: hit['_source'] as Map<String, dynamic>,
             meta: hit['_meta'] as Map<String, dynamic>))
@@ -25,10 +25,10 @@ class UserSearchResult extends KuzzleSearchResult {
 
   @override
   Future<List<dynamic>> next() => super.next().then((_) => hits =
-      (response.result['hits'] as List).map((hit) => User(kuzzle,
+      (response.result['hits'] as List).map((hit) => KuzzleUser(kuzzle,
           uid: hit['_id'] as String,
           content: hit['_source'] as Map<String, dynamic>,
           meta: hit['_meta'] as Map<String, dynamic>)) as List<dynamic>);
 
-  List<User> getUsers() => List<User>.from(hits);
+  List<KuzzleUser> getUsers() => List<KuzzleUser>.from(hits);
 }

--- a/test/authentication_test.dart
+++ b/test/authentication_test.dart
@@ -7,7 +7,7 @@ import 'helpers/kuzzle.dart';
 void main() {
   final kuzzle = Kuzzle(WebSocketProtocol('localhost'));
   Map<String, dynamic> credentials;
-  User user;
+  KuzzleUser user;
   setUpAll(() async {
     await connectKuzzle(kuzzle);
     final uuid = Uuid();
@@ -15,7 +15,7 @@ void main() {
       'username': uuid.v1(),
       'password': uuid.v1(),
     };
-    user = User(kuzzle, content: {
+    user = KuzzleUser(kuzzle, content: {
       'name': 'Test User',
       'profileIds': <String>['default'],
     });


### PR DESCRIPTION
Renamed `User`, `Profile`, `Role` and `Room` with `Kuzzle` prefix to avoid conflict with end user application class names.